### PR TITLE
Fix Outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 EnergyPlus*
 Gemfile.lock
 *.log
+decent_ci.log*

--- a/lib/cmake.rb
+++ b/lib/cmake.rb
@@ -171,7 +171,7 @@ module CMake
     test_dirs.each {|test_dir|
       $logger.info("Running tests in dir: '#{test_dir}'")
       env = {"PATH" => cmake_remove_git_from_path(ENV['PATH'])}
-      test_stdout, test_stderr, test_result = run_script(["cd #{build_dir}/#{test_dir} && #{@config.ctest_bin} -j #{compiler[:num_parallel_builds]} --timeout 3600 -D ExperimentalTest -C #{build_type} #{ctest_filter}"], env);
+      test_stdout, test_stderr, test_result = run_script(["cd #{build_dir}/#{test_dir} && #{@config.ctest_bin} -j #{compiler[:num_parallel_builds]} --timeout 4200 --no-compress-output -D ExperimentalTest -C #{build_type} #{ctest_filter}"], env);
       test_results, test_messages = process_ctest_results compiler, src_dir, build_dir, "#{build_dir}/#{test_dir}", test_stdout, test_stderr, test_result
 
       if @test_results.nil?

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -1139,9 +1139,7 @@ class PotentialBuild
 #{test_results_failure_counts_str}
 
 #{build_badge} #{test_badge} #{coverage_badge}
-          eos
-
-
+eos
     end
 
     if !@test_run

--- a/send_to_s3.py
+++ b/send_to_s3.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-
 from __future__ import print_function
 
 import boto
@@ -18,17 +17,13 @@ try:
         eprint("Error connecting to s3, trying again: {0}".format(e))
         conn = boto.connect_s3()
 
-
-
     bucketname = sys.argv[1]
     bucket = conn.get_bucket(bucketname)
 
     buildname = sys.argv[2]
     sourcedir = sys.argv[3]
     destdir = sys.argv[4]
-
     filedir = "{0}/{1}-{2}".format(destdir, datetime.datetime.now().date().isoformat(), buildname);
-
 
     for root, subFolders, files in os.walk(sourcedir):
         for file in files:
@@ -42,15 +37,12 @@ try:
             elif (filepath.endswith(".svg")):
                 content_type = {"Content-Type": "image/svg+xml"}
             else:
-                content_type = {"Content-Type": "application/octect-stream"}
+                content_type = {"Content-Type": "application/octet-stream"}
 
             key.set_contents_from_string(file_to_send.read(), headers=content_type)
             key.make_public()
-
 
     print("http://{0}.s3-website-{1}.amazonaws.com/{2}".format(bucketname, "us-east-1", filedir))
 
 except Exception as e:
     print("Error uploading files: {0}".format(e))
-
-


### PR DESCRIPTION
Branch name is not appropriate for these changes, but anyway:

- Bump timeout up for simulations to 4200, if that doesn't allow the debug runs to succeed then I'm just taking it back down
- Disable test output compression, to allow us to actually see outputs from simulations!
- Fix octet typo in s3 script