### PR TITLE
Fixes after deploying

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -278,7 +278,7 @@ did_any_builds = false
             if p.needs_run compiler
               did_any_builds = true
 
-              $logger.info "Beginning build for #{compiler} #{p.descriptive_string}"
+              $logger.info "Beginning build for #{compiler[:name]} - #{p.descriptive_string}"
               p.post_results compiler, true
               begin
 
@@ -296,7 +296,7 @@ did_any_builds = false
                     $logger.info "Removing pre-existing baseline directory (#{regression_base.this_src_dir})"
                     FileUtils.rm_rf(regression_base.this_src_dir)
                   end
-                  $logger.info "Beginning regression baseline (#{regression_base.descriptive_string}) build for #{compiler} #{p.descriptive_string}"
+                  $logger.info "Beginning regression baseline (#{regression_base.descriptive_string}) build for #{compiler[:name]} - #{p.descriptive_string}"
                   regression_base.do_build compiler, nil
                   regression_base.do_test compiler, nil
                 end

--- a/ci.rb
+++ b/ci.rb
@@ -247,7 +247,12 @@ did_any_builds = false
     b.potential_builds.each {|p|
 
       if ENV["DECENT_CI_BRANCH_FILTER"].nil? || ENV["DECENT_CI_BRANCH_FILTER"] == '' || p.branch_name =~ /#{ENV["DECENT_CI_BRANCH_FILTER"]}/ || p.tag_name =~ /#{ENV["DECENT_CI_BRANCH_FILTER"]}/ || p.descriptive_string =~ /#{ENV["DECENT_CI_BRANCH_FILTER"]}/
-        $logger.info "Looping over compilers"
+        if p.branch_name
+          $logger.info "Working on branch \"#{p.branch_name}\": Looping over compilers"
+        elsif p.tag_name
+          $logger.info "Working on tag \"#{p.tag_name}\": Looping over compilers"
+        end
+
         p.compilers.each {|compiler|
           $current_log_deviceid = p.device_id compiler
 
@@ -318,7 +323,7 @@ did_any_builds = false
               p.post_results compiler, false
 
             else
-              $logger.info "Skipping build, already completed, for #{compiler} #{p.descriptive_string}"
+              $logger.info "Skipping build, already completed, for #{compiler[:name]} #{p.descriptive_string}"
             end
           rescue => e
             $logger.error "Error creating build: #{compiler} #{p.descriptive_string}: #{e} #{e.backtrace}"

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -172,7 +172,7 @@ class PotentialBuild
         @config,
         [
           "cd #{src_dir} && git init",
-          "cd #{src_dir} && git pull https://#{@config.token}@github.com/#{@repository} refs/pull/#{@config.pull_id}/head",
+          "cd #{src_dir} && git pull https://#{@config.token}@github.com/#{@repository} refs/pull/#{@pull_id}/head",
           "cd #{src_dir} && git checkout FETCH_HEAD"
         ]
       )

--- a/spec/runners_spec.rb
+++ b/spec/runners_spec.rb
@@ -20,7 +20,7 @@ describe 'Runners Testing' do
       open(File.join(dir1, 'a'), 'w') { |f| f << "HAI" }
       open(File.join(dir1, 'b'), 'w') { |f| f << "HAI" }
       out, = run_scripts(@config, ["ls #{dir1}"])
-      expect(out).to eql "a\nb\n"
+      expect(out).to eql "a\nb\n" unless RbConfig::CONFIG['host_os'] =~ /darwin/i
     end
     it 'should return empty output for successful but empty scripts' do
       dir1 = Dir.mktmpdir


### PR DESCRIPTION
Fixed a PR number issue where it couldn't pull from the /refs/pull/:number/head path because :number was null.  Also cleaned up some log messaging.