### PR TITLE
Remove extra tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,16 @@ Style/RescueStandardError:
 Style/EachWithObject:
   Enabled: false
 
+# These were added by rubocop later
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 # We're letting codeclimate do this analysis
 Metrics/BlockNesting:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
 # *** Permanent Settings *** #
 
 # This could be adjusted but does not bother me
-Metrics/LineLength:
+Layout/LineLength:
   Max: 200
 
 # This is the one allowed global :-)
@@ -22,14 +22,14 @@ Style/HashSyntax:
   EnforcedStyle: no_mixed_keys
 
 # our heredocs are carefully crafted and need to have no whitespace indentation
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # This requires a semantic change and I'm not doing that anytime soon
 Security/YAMLLoad:
   Enabled: false
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: false
 
 # ************************** #

--- a/lib/cmake.rb
+++ b/lib/cmake.rb
@@ -8,10 +8,9 @@ class CMakeBuildArgs
   attr_reader :this_device_id
   attr_reader :this_running_extra
   attr_reader :is_release
-  def initialize(build_type, device_id, running_extra_tests, is_release = false)
+  def initialize(build_type, device_id, is_release = false)
     @build_type = build_type
     @this_device_id = device_id
-    @this_running_extra = running_extra_tests
     @is_release = is_release
   end
 end
@@ -27,10 +26,6 @@ module CMake
 
     compiler_extra_flags = compiler[:compiler_extra_flags]
     compiler_extra_flags = '' if compiler_extra_flags.nil?
-
-    if cmake_build_args.this_running_extra
-      cmake_flags = cmake_flags + ' ' + @config.extra_tests_cmake_extra_flags unless @config.extra_tests_cmake_extra_flags.nil?
-    end
 
     if cmake_build_args.is_release
       extra_flags = compiler[:release_build_cmake_extra_flags]
@@ -186,12 +181,8 @@ module CMake
     package_names
   end
 
-  def cmake_test(compiler, src_dir, build_dir, build_type, running_extra_here)
+  def cmake_test(compiler, src_dir, build_dir, build_type)
     test_dirs = [''] # always start with the root build directory
-
-    if running_extra_here
-      test_dirs << @config.extra_tests_test_dir unless @config.extra_tests_test_dir.nil?
-    end
 
     ctest_filter = compiler[:ctest_filter]
     ctest_filter = '' if ctest_filter.nil?

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -180,12 +180,12 @@ module Configuration
       raise 'Version number for visual studio must be provided'
     when 'clang'
       /.*clang version (?<version>([0-9]+\.?)+).*/ =~ `clang --version`
-      return version
+      version
     when 'gcc'
-      return `gcc -dumpversion`
+      `gcc -dumpversion`
     when 'cppcheck', 'custom_check'
       # we can actually leave the version nil for cppcheck, it will allow a version-agnostic spec
-      return nil
+      nil
     else
       raise 'Invalid compiler specified, must be one of clang, gcc, custom_check, cppcheck, or a variation on "Visual Studio VV YYYY"'
     end

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -112,15 +112,6 @@ class PotentialBuild
     !@pull_id.nil?
   end
 
-  def running_extra_tests
-    # TODO: I think we can get rid of this function and accompanying variables
-    if !@branch_name.nil? && !@config.extra_tests_branches.nil? && @config.extra_tests_branches.count(@branch_name) != 0
-      true
-    else
-      false
-    end
-  end
-
   def device_tag(compiler)
     build_type_tag = ''
     build_type_tag = "-#{compiler[:build_tag]}" unless compiler[:build_tag].nil?
@@ -341,7 +332,7 @@ class PotentialBuild
       cppcheck @config, compiler, src_dir, build_dir
     else
       this_device_id = device_id compiler
-      args = CMakeBuildArgs.new(compiler[:build_type], this_device_id, running_extra_tests, is_release)
+      args = CMakeBuildArgs.new(compiler[:build_type], this_device_id, is_release)
       cmake_build compiler, src_dir, build_dir, this_regression_dir, regression_baseline, args if checkout_succeeded
     end
     @build_time = 0 if @build_time.nil?
@@ -359,7 +350,7 @@ class PotentialBuild
     else
       start_time = Time.now
       if !ENV['DECENT_CI_SKIP_TEST']
-        cmake_test compiler, src_dir, build_dir, compiler[:build_type], running_extra_tests if build_succeeded
+        cmake_test compiler, src_dir, build_dir, compiler[:build_type] if build_succeeded
       else
         $logger.debug('Skipping test, DECENT_CI_SKIP_TEST is set in the environment')
       end

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -257,7 +257,7 @@ class PotentialBuild
       files.each do |f|
         file_names << f.name
       end
-    rescue Octokit::NotFound # rubocop:disable Lint/HandleExceptions
+    rescue Octokit::NotFound # rubocop:disable Lint/SuppressedException
       # repository doesn't have a _posts folder yet
     end
 

--- a/lib/potentialbuild.rb
+++ b/lib/potentialbuild.rb
@@ -481,7 +481,7 @@ class PotentialBuild
 
     props['object_files'] = []
 
-    object_files.values.each do |this_file|
+    object_files.each_value do |this_file|
       abs_path = File.absolute_path(this_file, build_dir)
       next unless abs_path.start_with?(File.absolute_path(build_dir)) && File.exist?(abs_path)
 

--- a/lib/resultsprocessor.rb
+++ b/lib/resultsprocessor.rb
@@ -12,12 +12,12 @@ module ResultsProcessor
     Pathname.new("#{src_dir}/#{path}").realpath.relative_path_from(Pathname.new(this_src_dir).realdirpath)
   rescue
     begin
-      return Pathname.new("#{build_dir}/#{path}").realpath.relative_path_from(Pathname.new(this_src_dir).realdirpath)
+      Pathname.new("#{build_dir}/#{path}").realpath.relative_path_from(Pathname.new(this_src_dir).realdirpath)
     rescue
       begin
-        return Pathname.new(path).realpath.relative_path_from(Pathname.new(this_src_dir).realdirpath)
+        Pathname.new(path).realpath.relative_path_from(Pathname.new(this_src_dir).realdirpath)
       rescue
-        return Pathname.new(path)
+        Pathname.new(path)
       end
     end
   end

--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -99,7 +99,7 @@ module Runners
           err << stderr.read_nonblock(4096)
         end
       end
-    rescue IO::WaitReadable # rubocop:disable Lint/HandleExceptions
+    rescue IO::WaitReadable # rubocop:disable Lint/SuppressedException
       # A read would block, so loop around for another select
     rescue EOFError
       # Command has completed, not really an error...

--- a/send_to_s3.py
+++ b/send_to_s3.py
@@ -23,7 +23,7 @@ try:
     buildname = sys.argv[2]
     sourcedir = sys.argv[3]
     destdir = sys.argv[4]
-    filedir = "{0}/{1}-{2}".format(destdir, datetime.datetime.now().date().isoformat(), buildname);
+    filedir = "{0}/{1}-{2}".format(destdir, datetime.datetime.now().date().isoformat(), buildname)
 
     for root, subFolders, files in os.walk(sourcedir):
         for file in files:

--- a/spec/cmake_spec.rb
+++ b/spec/cmake_spec.rb
@@ -12,6 +12,13 @@ class DummyRegressionBuild
   end
 end
 
+class CMakeSpecNamedDummy
+  attr_reader :name
+  def initialize(this_name)
+    @name = this_name
+  end
+end
+
 describe 'CMake Testing' do
   include CMake
   include Configuration
@@ -20,7 +27,7 @@ describe 'CMake Testing' do
   context 'when calling cmake_build' do
     it 'should try to build a base release package' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
       compiler = @config.compilers.first
@@ -35,7 +42,7 @@ describe 'CMake Testing' do
     end
     it 'should try to build a release package with a target_arch key' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
       compiler = @config.compilers.first
@@ -51,7 +58,7 @@ describe 'CMake Testing' do
     end
     it 'should try to build a release without ccbin' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
       compiler = @config.compilers.first
@@ -67,7 +74,7 @@ describe 'CMake Testing' do
     end
     it 'should try to build a release with regressions' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
       compiler = @config.compilers.first
@@ -84,7 +91,7 @@ describe 'CMake Testing' do
   context 'when calling cmake_package' do
     it 'should try to build a simple package' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
       compiler = @config.compilers.first
@@ -95,7 +102,7 @@ describe 'CMake Testing' do
     end
     it 'should try to build but fail with no package results' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       allow_any_instance_of(ResultsProcessor).to receive(:process_cmake_results).and_return(nil)
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
@@ -107,7 +114,7 @@ describe 'CMake Testing' do
     end
     it 'should try to build and fail but with some package results' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       allow_any_instance_of(ResultsProcessor).to receive(:process_cmake_results).and_return(nil)
       @client = Octokit::Client.new(:access_token => 'abc')
       @config = load_configuration('spec/resources', 'abc', false)
@@ -119,7 +126,7 @@ describe 'CMake Testing' do
     end
     it 'should complete a build and return a proper name' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       allow_any_instance_of(ResultsProcessor).to receive(:process_cmake_results).and_return(true)
       allow_any_instance_of(ResultsProcessor).to receive(:parse_package_names).and_return(['hello'])
       @client = Octokit::Client.new(:access_token => 'abc')
@@ -136,7 +143,7 @@ describe 'CMake Testing' do
   context 'when calling cmake_test' do
     it 'should run a simple set of tests' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       allow_any_instance_of(ResultsProcessor).to receive(:process_cmake_results).and_return(true)
       allow_any_instance_of(ResultsProcessor).to receive(:process_ctest_results).and_return([[], []])
       @client = Octokit::Client.new(:access_token => 'abc')
@@ -145,11 +152,11 @@ describe 'CMake Testing' do
       src_dir = Dir.mktmpdir
       build_dir = File.join(src_dir, 'build')
       @test_messages = []
-      expect(cmake_test(compiler, src_dir, build_dir, 'Debug', true)).to be_truthy
+      expect(cmake_test(compiler, src_dir, build_dir, 'Debug')).to be_truthy
     end
     it 'should run a simple set of tests and concatenate test_results' do
       allow_any_instance_of(Runners).to receive(:run_scripts).and_return(['stdoutmsg', 'stderrmsg', 0])
-      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([NamedDummy.new('.decent_ci.yaml')])
+      allow_any_instance_of(Octokit::Client).to receive(:content).and_return([CMakeSpecNamedDummy.new('.decent_ci.yaml')])
       allow_any_instance_of(ResultsProcessor).to receive(:process_cmake_results).and_return(true)
       allow_any_instance_of(ResultsProcessor).to receive(:process_ctest_results).and_return([[], []])
       @client = Octokit::Client.new(:access_token => 'abc')
@@ -159,7 +166,7 @@ describe 'CMake Testing' do
       build_dir = File.join(src_dir, 'build')
       @test_results = []
       @test_messages = []
-      expect(cmake_test(compiler, src_dir, build_dir, 'Debug', true)).to be_truthy
+      expect(cmake_test(compiler, src_dir, build_dir, 'Debug')).to be_truthy
     end
   end
 end

--- a/spec/cmake_spec.rb
+++ b/spec/cmake_spec.rb
@@ -29,7 +29,7 @@ describe 'CMake Testing' do
       regression_dir = nil
       regression_baseline = nil
       @build_results = SortedSet.new
-      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true, true)
+      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true,)
       response = cmake_build(compiler,src_dir, build_dir, regression_dir, regression_baseline, args)
       expect(response).to be_truthy
     end
@@ -45,7 +45,7 @@ describe 'CMake Testing' do
       regression_dir = nil
       regression_baseline = nil
       @build_results = SortedSet.new
-      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true, true)
+      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true)
       response = cmake_build(compiler,src_dir, build_dir, regression_dir, regression_baseline, args)
       expect(response).to be_truthy
     end
@@ -61,7 +61,7 @@ describe 'CMake Testing' do
       regression_dir = nil
       regression_baseline = nil
       @build_results = SortedSet.new
-      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true, true)
+      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true)
       response = cmake_build(compiler,src_dir, build_dir, regression_dir, regression_baseline, args)
       expect(response).to be_truthy
     end
@@ -76,7 +76,7 @@ describe 'CMake Testing' do
       regression_dir = Dir.mktmpdir
       regression_baseline = DummyRegressionBuild.new('/dir/', 'abcd')
       @build_results = SortedSet.new
-      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true, true)
+      args = CMakeBuildArgs.new('Debug', 'thisDeviceIDHere', true)
       response = cmake_build(compiler,src_dir, build_dir, regression_dir, regression_baseline, args)
       expect(response).to be_truthy
     end

--- a/spec/potentialbuild_spec.rb
+++ b/spec/potentialbuild_spec.rb
@@ -337,14 +337,5 @@ fn=func2
       @p.configuration.compilers = 'hello'
       expect(@p.compilers).to eql 'hello'
     end
-    it 'running_extra_tests should only be true in specific conditions' do
-      expect(@p.running_extra_tests).to be_falsey
-      client = Octokit::Client.new(:access_token => 'abc')
-      @p = PotentialBuild.new(client, '', 'spec/resources', '', '', 'abc', '', '', '', 0, '', '')
-      expect(@p.running_extra_tests).to be_falsey
-      @p.configuration.extra_tests_branches = ['abc'] # with a test on this branch name, it should be truthy
-      expect(@p.running_extra_tests).to be_truthy
-    end
   end
 end
-


### PR DESCRIPTION
Remove anything related to running "extra tests".  We don't use this feature of Decent CI, and it's time to clean it out.  This also fixes a silly unit test import issue.  I may clean up some other random stuff here.

This is not intended to merge until after this E+ release.