### PR TITLE
Fix continually deleting external PR results

### DIFF
--- a/ci.rb
+++ b/ci.rb
@@ -143,6 +143,8 @@ def get_limits(t_options, t_client, t_repo)
       $logger.info("'#{e.message}' error while reading limits file")
     rescue Psych::SyntaxError => e
       $logger.info("'#{e.message}' error while reading limits file")
+    rescue Octokit::NotFound => e
+      $logger.info("No limits file found on this repository, moving on...")
     rescue => e
       $logger.info("'#{e.message}' '#{e.backtrace}' error while reading limits file")
     end

--- a/cleanup.rb
+++ b/cleanup.rb
@@ -264,7 +264,7 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
   files_for_deletion.each { |file|
     logger.info("Deleting results file: #{file.path}. Source branch #{file_branch[file.path]} removed, or file too old")
     begin
-      #  github_query(client) { client.delete_contents(results_repository, file.path, "Source branch #{file_branch[file.path]} removed. Deleting results.", file.sha) }
+      github_query(client) { client.delete_contents(results_repository, file.path, "Source branch #{file_branch[file.path]} removed. Deleting results.", file.sha) }
     rescue => e
       logger.error("Error deleting file: #{file.path} for branch #{file_branch[file.path]} message: #{e}")
     end

--- a/cleanup.rb
+++ b/cleanup.rb
@@ -50,12 +50,17 @@ def clean_up(client, repository, results_repository, results_path, age_limit, li
     logger.info("Total file limits reached, long running branch names: '#{branches}', feature branch file limit: '#{feature_branch_limit}', long running branch file limit: '#{long_running_branch_limit}'")
   end
 
+  # todo properly handle paginated results from github
+  _branches = github_query(client) { client.branches(repository, :per_page => 200) }
+  _releases = github_query(client) { client.releases(repository, :per_page => 200) }
+  _pull_requests = github_query(client) { client.pull_requests(repository, :state=>"open", :per_page => 50) }
+
   clean_up_impl(client, repository, results_repository, results_path, age_limit,
-                      limit_reached, branches, feature_branch_limit, long_running_branch_limit)
+                      limit_reached, branches, feature_branch_limit, long_running_branch_limit, _branches, _releases, _pull_requests)
 end
 
 def clean_up_impl(client, repository, results_repository, results_path, age_limit,
-                 limit_reached, long_running_branches, feature_branch_limit, long_running_branch_limit)
+                 limit_reached, long_running_branches, feature_branch_limit, long_running_branch_limit, branches, releases, pull_requests)
   if $logger.nil?
     logger = Logger.new(STDOUT)
   else
@@ -72,7 +77,7 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
     if file.type == "dir"
       # Scan sub-folder
       clean_up_impl(client, repository, results_repository, file.path, age_limit, 
-                    limit_reached, long_running_branches, feature_branch_limit, long_running_branch_limit)
+                    limit_reached, long_running_branches, feature_branch_limit, long_running_branch_limit, branches, releases, pull_requests)
     elsif file.type == "file"
       folder_contains_files = true
     end
@@ -82,7 +87,6 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
     # No reason to continue from here if no files are found
     return
   end
-
 
   branch_history_limit = 20
   file_age_limit = 9000
@@ -109,12 +113,6 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
     end
     logger.info("Hitting directory size limit #{files.size}, reducing history to #{branch_history_limit} data points")
   end
-
-
-  # todo properly handle paginated results from github
-  branches = github_query(client) { client.branches(repository, :per_page => 200) }
-  releases = github_query(client) { client.releases(repository, :per_page => 200) }
-  pull_requests = github_query(client) { client.pull_requests(repository, :state=>"open") }
 
   files_for_deletion = []
   branches_deleted = Set.new
@@ -172,7 +170,7 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
             end
           }
           unless pr_found
-            logger.debug("PR not found, queuing results file for deletion: #{file_data["title"]}")
+            logger.info("PR #{file_data["pull_request_issue_id"]} not found, queuing results file for deletion: #{file_data["title"]}")
             files_for_deletion << file
             prs_deleted << file_data["pull_request_issue_id"]
           end
@@ -266,7 +264,7 @@ def clean_up_impl(client, repository, results_repository, results_path, age_limi
   files_for_deletion.each { |file|
     logger.info("Deleting results file: #{file.path}. Source branch #{file_branch[file.path]} removed, or file too old")
     begin
-      github_query(client) { client.delete_contents(results_repository, file.path, "Source branch #{file_branch[file.path]} removed. Deleting results.", file.sha) }
+      #  github_query(client) { client.delete_contents(results_repository, file.path, "Source branch #{file_branch[file.path]} removed. Deleting results.", file.sha) }
     rescue => e
       logger.error("Error deleting file: #{file.path} for branch #{file_branch[file.path]} message: #{e}")
     end


### PR DESCRIPTION
We kept seeing CI running external PRs over and over.  Even though everything seemed to be fine.  I realized that CI was deleting results every evening and then re-running them and never getting caught up.

The root of the problem was found to be an issue during cleanup.  When CI runs cleanup, it pulls the current branch list, PR list, and release list.  It then loops over all results files in the results repo and verifies the files match an existing branch, PR, or tag.  If it doesn't, it deletes the results, keeping the dashboard and results repo updated and clean.  However, there was an issue with the PR list.  It by default only grabs 30 pull requests.  We often have more than 30 pull requests open, so results for PRs older than 30 were being pruned because they didn't belong to any known PR.

This fix bumps the value up to 50...sheesh we shouldn't have near that much...so now the results should stay as long as the PR is open.

Some other minor cleanups along the way:
 - Capture `Octokit::NotFound` when searching for the `.decent_ci-limits.yaml` file, no need to throw an error
 - Only look up the branches, releases, and pull requests once at the beginning of the cleanup process, rather than finding them on each individual file.  There shouldn't be any other cleanups going on at the same time so I think this should be fine.  And hopefully it will speed up the cleanup process as a whole.