### PR TITLE
Build test branch before baseline branch

### DIFF
--- a/lib/cmake.rb
+++ b/lib/cmake.rb
@@ -192,7 +192,7 @@ module CMake
       env = { 'PATH' => cmake_remove_git_from_path(ENV['PATH']) }
       _, test_stderr, test_result = run_scripts(
         @config,
-        ["cd #{build_dir}/#{test_dir} && #{@config.ctest_bin} -j #{compiler[:num_parallel_builds]} --timeout 4200 --no-compress-output -D ExperimentalTest -C #{build_type} #{ctest_filter}"],
+        ["cd #{build_dir}/#{test_dir} && #{@config.ctest_bin} -j #{compiler[:num_parallel_builds]} --timeout 4800 --no-compress-output -D ExperimentalTest -C #{build_type} #{ctest_filter}"],
         env
       )
       test_results, test_messages = process_ctest_results src_dir, build_dir, "#{build_dir}/#{test_dir}"


### PR DESCRIPTION
The description is really in the changed files but basically, we want to try to build the test branch first so that if it is removed, we don't waste time building the baseline branch.