### PR TITLE
Adding support for doc tests

### DIFF
--- a/lib/resultsprocessor.rb
+++ b/lib/resultsprocessor.rb
@@ -437,7 +437,7 @@ module ResultsProcessor
     #   including the ones that test the build logs, and those tests will have created json blobs.  We should find those
     #   and try to parse them to produce test results
     doc_build_dir = File.join(build_dir, 'doc')
-    if File.exists? doc_build_dir
+    if File.exist? doc_build_dir
       Find.find(doc_build_dir) do |path|
         next unless path.match(/._errors.json/)
 
@@ -472,6 +472,7 @@ module ResultsProcessor
       test_results = xml['Site']['Testing']
       t = test_results['Test']
       next if t.nil?
+
       tests = []
       tests << t
       tests.flatten!

--- a/lib/resultsprocessor.rb
+++ b/lib/resultsprocessor.rb
@@ -436,26 +436,27 @@ module ResultsProcessor
     # the docs are built as part of the normal "make" command on CI, then the "ctest" command executes all the tests,
     #   including the ones that test the build logs, and those tests will have created json blobs.  We should find those
     #   and try to parse them to produce test results
-    doc_build_dir = File.join(build_dir, "doc")
-    Find.find(doc_build_dir) do |path|
-      next unless path.match(/._errors.json/)
-      f = File.open(path, 'r')
-      contents = f.read
-      json = JSON.parse(contents)
-      json['issues'].each do |issue|
-        severity_raw = issue['severity']
-        status = 'failed'
-        severity = 'error'
-        if severity_raw.upcase == 'WARNING'
-          severity = 'warning'
+    doc_build_dir = File.join(build_dir, 'doc')
+    if File.exists? doc_build_dir
+      Find.find(doc_build_dir) do |path|
+        next unless path.match(/._errors.json/)
+
+        f = File.open(path, 'r')
+        contents = f.read
+        json = JSON.parse(contents)
+        json['issues'].each do |issue|
+          severity_raw = issue['severity']
+          status = 'failed'
+          severity = 'error'
+          severity = 'warning' if severity_raw.upcase == 'WARNING'
+          full_message = ''
+          full_message += issue['type']
+          file_name = issue['locations'][0]['file']
+          line_number = issue['locations'][0]['line']
+          full_message += ': ' + issue['message']
+          doc_errors = [CodeMessage.new(file_name, line_number, 0, severity, full_message)]
+          results << TestResult.new(file_name, status, 0, full_message, doc_errors, 1)
         end
-        full_message = ''
-        full_message += issue['type']
-        file_name = issue['locations'][0]['file']
-        line_number = issue['locations'][0]['line']
-        full_message += ': ' + issue['message']
-        doc_errors = [CodeMessage.new(file_name, line_number, 0, severity, full_message)]
-        results << TestResult.new(file_name, status, 0, full_message, doc_errors, 1)
       end
     end
 
@@ -470,50 +471,49 @@ module ResultsProcessor
       xml = Hash.from_xml(contents)
       test_results = xml['Site']['Testing']
       t = test_results['Test']
-      unless t.nil?
-        tests = []
-        tests << t
-        tests.flatten!
+      next if t.nil?
+      tests = []
+      tests << t
+      tests.flatten!
 
-        tests.each do |n|
-          $logger.debug("N: #{n}")
-          $logger.debug("Results: #{n['Results']}")
-          r = n['Results']
-          if n['Status'] == 'notrun'
-            results << TestResult.new(n['Name'], n['Status'], 0, '', nil, 'notrun')
-          elsif r
-            m = r['Measurement']
-            value = nil
-            errors = nil
+      tests.each do |n|
+        $logger.debug("N: #{n}")
+        $logger.debug("Results: #{n['Results']}")
+        r = n['Results']
+        if n['Status'] == 'notrun'
+          results << TestResult.new(n['Name'], n['Status'], 0, '', nil, 'notrun')
+        elsif r
+          m = r['Measurement']
+          value = nil
+          errors = nil
 
-            unless m.nil? || m['Value'].nil?
-              value = m['Value']
-              errors = parse_error_messages(src_dir, build_dir, value)
-              value.split("\n").each do |line|
-                if /\[decent_ci:test_result:message\] (?<message>.+)/ =~ line
-                  messages << TestMessage.new(n['Name'], message)
-                end
+          unless m.nil? || m['Value'].nil?
+            value = m['Value']
+            errors = parse_error_messages(src_dir, build_dir, value)
+            value.split("\n").each do |line|
+              if /\[decent_ci:test_result:message\] (?<message>.+)/ =~ line
+                messages << TestMessage.new(n['Name'], message)
               end
             end
+          end
 
-            nm = r['NamedMeasurement']
+          nm = r['NamedMeasurement']
 
-            unless nm.nil?
-              failure_type = ''
-              nm.each do |measurement|
-                next if measurement['name'] != 'Exit Code'
+          unless nm.nil?
+            failure_type = ''
+            nm.each do |measurement|
+              next if measurement['name'] != 'Exit Code'
 
-                ft = measurement['Value']
-                failure_type = ft unless ft.nil?
-              end
+              ft = measurement['Value']
+              failure_type = ft unless ft.nil?
+            end
 
-              nm.each do |measurement|
-                next if measurement['name'] != 'Execution Time'
+            nm.each do |measurement|
+              next if measurement['name'] != 'Execution Time'
 
-                status_string = n['Status']
-                status_string = 'warning' if !value.nil? && value =~ /\[decent_ci:test_result:warn\]/ && status_string == 'passed'
-                results << TestResult.new(n['Name'], status_string, measurement['Value'], value, errors, failure_type)
-              end
+              status_string = n['Status']
+              status_string = 'warning' if !value.nil? && value =~ /\[decent_ci:test_result:warn\]/ && status_string == 'passed'
+              results << TestResult.new(n['Name'], status_string, measurement['Value'], value, errors, failure_type)
             end
           end
         end

--- a/spec/resultsprocessor_spec.rb
+++ b/spec/resultsprocessor_spec.rb
@@ -403,5 +403,57 @@ describe 'ResultsProcessor Testing' do
       expect(results.length).to eql 1646
       expect(messages.length).to eql 0
     end
+    it 'should process doc build json error files in build/doc' do
+      temp_dir = Dir.mktmpdir
+      temp_build_dir = Dir.mktmpdir
+      doc_build_dir = File.join(temp_build_dir, 'doc')
+      Dir.mkdir(doc_build_dir)
+      doc_build_error_file = File.join(doc_build_dir, 'something_errors.json')
+      json_data = {
+          "log_file_path": "/eplus/repos/forks/doc/engineering-reference/engineering-reference.log",
+          "issues": [
+              {
+                  "severity": "WARNING",
+                  "type": "Hyper reference undefined",
+                  "locations": [
+                      {
+                          "file": "src/climate-sky-and-solar-shading-calculations/shading-module.tex",
+                          "line": 176
+                      }
+                  ],
+                  "message": " Hyper reference `surfacePropertylocalEnvironment' on page 205 undefined on input line 176.\n",
+                  "label": "surfacePropertylocalEnvironment"
+              },
+              {
+                  "severity": "WARNING",
+                  "type": "Hyper reference undefined",
+                  "locations": [
+                      {
+                          "file": "src/climate-sky-and-solar-shading-calculations/shading-module.tex",
+                          "line": 177
+                      }
+                  ],
+                  "message": " Hyper reference `schedulefileshading' on page 205 undefined on input line 177.\n",
+                  "label": "schedulefileshading"
+              },
+              {
+                  "severity": "WARNING",
+                  "type": "Package hyperref",
+                  "locations": [
+                      {
+                          "file": "src/demand-limiting.tex",
+                          "line": 22
+                      }
+                  ],
+                  "message": "Difference (2) between bookmark levels is greater (hyperref)                than one, level fixed on input line 22."
+              }
+          ]
+      }
+      json_content = JSON.dump(json_data)
+      open(doc_build_error_file, 'w') { |f| f << json_content }
+      results, messages = process_ctest_results("/src/dir", temp_build_dir, temp_dir)
+      expect(results.length).to eql 3
+        # expect(results[0].parsed_errors[0].linenumber).to eql 176
+    end
   end
 end


### PR DESCRIPTION
Done:
 - Checks for existence of doc build folder, and if found, processes any `_error.json` files
 - Parses the json files and converts them into appropriate build results and code messages
 - Added a unit test that tests an example error json output

To Do:
 - Adapt code and unit test for final version of JSON output file
 - Make sure build result and test result are both handled as expected
 - Unit test numerous other cases -- missing JSON keys, etc.