### PR TITLE
Rearranging timing where CI finds LaTeX issues

### DIFF
--- a/lib/cmake.rb
+++ b/lib/cmake.rb
@@ -106,7 +106,7 @@ module CMake
     gcc_success = process_gcc_results(src_dir, build_dir, err, result)
     process_cmake_results(src_dir, build_dir, err, result, false)
     process_python_results(src_dir, build_dir, out, err, result)
-    process_latex_results(build_dir)  # not worrying about an exit code for now
+    process_latex_results(build_dir) # not worrying about an exit code for now
     msvc_success && gcc_success
   end
 

--- a/lib/cmake.rb
+++ b/lib/cmake.rb
@@ -106,6 +106,7 @@ module CMake
     gcc_success = process_gcc_results(src_dir, build_dir, err, result)
     process_cmake_results(src_dir, build_dir, err, result, false)
     process_python_results(src_dir, build_dir, out, err, result)
+    process_latex_results(build_dir)  # not worrying about an exit code for now
     msvc_success && gcc_success
   end
 


### PR DESCRIPTION
- Moved LaTeX error file parser to standalone function
- Moved call to this into the make portion, not the ctest portion
- Changed it to append to build_results instead of test_results
- Removed LaTeX parsing from Python parsing function
- Fixed up unit test accordingly