### PR TITLE
Upload to s3 in binary mode to get coverage uploads working

### DIFF
--- a/send_to_s3.py
+++ b/send_to_s3.py
@@ -7,8 +7,10 @@ import sys
 import os
 import datetime
 
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
+
 
 try:
     try:
@@ -27,15 +29,17 @@ try:
 
     for root, subFolders, files in os.walk(sourcedir):
         for file in files:
-            filename = os.path.join(root,file)
+            filename = os.path.join(root, file)
             filepath = "{0}/{1}".format(filedir, os.path.relpath(filename, sourcedir))
             print("{0} => {1}".format(filename, filepath), file=sys.stderr)
             key = boto.s3.key.Key(bucket, filepath)
-            file_to_send = open(filename, 'r')
+            file_to_send = open(filename, 'rb')
             if (filepath.endswith(".html")):
                 content_type = {"Content-Type": "text/html"}
             elif (filepath.endswith(".svg")):
                 content_type = {"Content-Type": "image/svg+xml"}
+            elif (filepath.endswith(".png")):
+                content_type = {"Content-Type": "image/png"}
             else:
                 content_type = {"Content-Type": "application/octet-stream"}
 


### PR DESCRIPTION
(Sorry, branch name is a misnomer)

Anyway, with the update to Ubuntu 22.04 and updated Python/boto, the coverage results would no longer upload.  After some deep detective work, I found it was barfing trying to upload a genhtml asset called ruby.png.  The file was being read in plain text, but included invalid utf-8 start characters.  The file needed to be uploaded in binary mode, so I modified the s3 script, and it works happily.  I was able to upload a full set of coverage results and browse them happily, so I think this should be a fine change.  I'm going to merge and if something fails, I'll revert back to just changing the read mode specifically for certain file types.