### PR TITLE
Add support for VS 2022

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -200,7 +200,8 @@ module Configuration
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
     if compiler[:name].match(/.*Visual Studio.*/i)
-      case compiler.fetch('version', nil)
+      found_version = compiler.fetch(:version, nil)
+      case found_version
       when 16
         'Visual Studio 16 2019'
       when 17

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -200,7 +200,7 @@ module Configuration
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
     if compiler[:name].match(/.*Visual Studio.*/i)
-      case compiler.fetch("version", nil)
+      case compiler.fetch('version', nil)
       when 16
         'Visual Studio 16 2019'
       when 17

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -200,9 +200,10 @@ module Configuration
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
     if compiler[:name].match(/.*Visual Studio.*/i)
-      if compiler[:version] == 16
+      case compiler[:version]
+      when 16
         'Visual Studio 16 2019'
-      elsif compiler[:version] == 17
+      when 17
         'Visual Studio 17 2022'
       else
         raise CannotMatchCompiler, 'For Visual Studio, must specify version as either 16 or 17'

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -200,7 +200,7 @@ module Configuration
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
     if compiler[:name].match(/.*Visual Studio.*/i)
-      case compiler[:version]
+      case compiler.fetch("version", nil)
       when 16
         'Visual Studio 16 2019'
       when 17

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -199,10 +199,14 @@ module Configuration
   def setup_compiler_build_generator(compiler)
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
-    if compiler[:name].match(/.*Visual Studio.*/i) && compiler[:version] == 16
-      'Visual Studio 16 2019'
-    elsif compiler[:name].match(/.*Visual Studio.*/i) && compiler[:version] == 17
-      'Visual Studio 17 2022'      
+    if compiler[:name].match(/.*Visual Studio.*/i)
+      if compiler[:version] == 16
+        'Visual Studio 16 2019'
+      elsif compiler[:version] == 17
+        'Visual Studio 17 2022'
+      else
+        raise CannotMatchCompiler, 'For Visual Studio, must specify version as either 16 or 17'
+      end
     else
       'Unix Makefiles'
     end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -199,8 +199,10 @@ module Configuration
   def setup_compiler_build_generator(compiler)
     return compiler[:build_generator] unless compiler[:build_generator].nil?
 
-    if compiler[:name].match(/.*Visual Studio.*/i)
+    if compiler[:name].match(/.*Visual Studio.*/i) && compiler[:version] == 16
       'Visual Studio 16 2019'
+    elsif compiler[:name].match(/.*Visual Studio.*/i) && compiler[:version] == 17
+      'Visual Studio 17 2022'      
     else
       'Unix Makefiles'
     end
@@ -268,7 +270,7 @@ module Configuration
     compiler[:cmake_extra_flags] = setup_compiler_extra_flags(compiler, is_release)
     compiler[:num_parallel_builds] = setup_compiler_num_processors(compiler)
 
-    raise CannotMatchCompiler, 'Decent CI currently only deployed with Visual Studio version 16 (2019)' if compiler[:name] =~ /.*Visual Studio.*/i && compiler[:version] != 16
+    raise CannotMatchCompiler, 'Decent CI currently only deployed with Visual Studio version 16 (2019) and 17 (2022)' if compiler[:name] =~ /.*Visual Studio.*/i && !compiler[:version].in?([16, 17])
 
     compiler
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -196,7 +196,9 @@ describe 'Configuration Testing' do
   context 'when calling setup_compiler_build_generator' do
     it 'should return the correct build generator' do
       expect(setup_compiler_build_generator({:build_generator => 'Already here'})).to eql 'Already here'
-      expect(setup_compiler_build_generator({:name => 'Visual Studio Hello'})).to include 'Visual Studio'
+      expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 16})).to include 'Visual Studio'
+      expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 17})).to include 'Visual Studio'
+      expect(setup_compiler_build_generator({:name => 'Visual Studio'})).to raise_error(RuntimeError)
       expect(setup_compiler_build_generator({:name => 'gccc'})).to include 'Unix'
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -194,11 +194,11 @@ describe 'Configuration Testing' do
     end
   end
   context 'when calling setup_compiler_build_generator' do
-    it 'should return the correct build generator' do
+    it 'should return the correct build generator or raise' do
       expect(setup_compiler_build_generator({:build_generator => 'Already here'})).to eql 'Already here'
       expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 16})).to include 'Visual Studio'
       expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 17})).to include 'Visual Studio'
-      expect(setup_compiler_build_generator({:name => 'Visual Studio'})).to raise_error(CannotMatchCompiler)
+      expect { setup_compiler_build_generator({:name => 'Visual Studio', :version => 198}) }.to raise_exception(CannotMatchCompiler)
       expect(setup_compiler_build_generator({:name => 'gccc'})).to include 'Unix'
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -198,7 +198,7 @@ describe 'Configuration Testing' do
       expect(setup_compiler_build_generator({:build_generator => 'Already here'})).to eql 'Already here'
       expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 16})).to include 'Visual Studio'
       expect(setup_compiler_build_generator({:name => 'Visual Studio', :version => 17})).to include 'Visual Studio'
-      expect(setup_compiler_build_generator({:name => 'Visual Studio'})).to raise_error(RuntimeError)
+      expect(setup_compiler_build_generator({:name => 'Visual Studio'})).to raise_error(CannotMatchCompiler)
       expect(setup_compiler_build_generator({:name => 'gccc'})).to include 'Unix'
     end
   end


### PR DESCRIPTION
The new CI machine has Visual Studio 2022, not 2019.  I thought about installing 2019, but I don't think I will.  I think I'd rather just move the other machine up to 2022.  Needed a tweak to Decent before doing that.  This change will allow us to initially add a second Windows Decent run with 2022.  Then install 2022 on the older machine.  Once everything settles, eliminate the 2019 build.  